### PR TITLE
Moved GradleHelper creation under gradle_task

### DIFF
--- a/lib/fastlane/plugin/automated_test_emulator_run/actions/automated_test_emulator_run_action.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run/actions/automated_test_emulator_run_action.rb
@@ -139,8 +139,6 @@ module Fastlane
           end
 
           # Launching tests
-          gradle = Helper::GradleHelper.new(gradle_path: Dir["./gradlew"].last)
-
           shell_task = "#{params[:shell_task]}" unless params[:shell_task].nil?
           gradle_task = "#{params[:gradle_task]}" unless params[:gradle_task].nil?
 
@@ -152,6 +150,8 @@ module Fastlane
             end
 
             unless gradle_task.nil?
+              gradle = Helper::GradleHelper.new(gradle_path: Dir["./gradlew"].last)
+
               UI.message("Using gradle task.".green)
               gradle.trigger(task: params[:gradle_task], flags: params[:gradle_flags], serial: nil)
             end


### PR DESCRIPTION
First of all, thanks for the plugin, good job!

We've encountered an issue, the plugin crashes when the ./gradlew isn't located in the root folder, because of this [line](https://github.com/AzimoLabs/fastlane-plugin-automated-test-emulator-run/blob/master/lib/fastlane/plugin/automated_test_emulator_run/actions/automated_test_emulator_run_action.rb#L142). We would like to use the shell_task anyway, so this PR is a possible fix.

GradleHelper will only be created when executing gradle_task.