### PR TITLE
Add support for getting log from logcat

### DIFF
--- a/lib/fastlane/plugin/automated_test_emulator_run/actions/automated_test_emulator_run_action.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run/actions/automated_test_emulator_run_action.rb
@@ -149,7 +149,10 @@ module Fastlane
             
             if all_avd_launched
               UI.message("AVDs Booted!".green)
-              Action.sh(adb_controller.command_clear_logcat)
+              for i in 0...avd_schemes.length
+                device = ["emulator-", avd_schemes[i].launch_avd_port].join("")
+                Action.sh(adb_controller.command_clear_logcat(device: device)) unless devices.match(device).nil?
+              end
             else
               for i in 0...avd_schemes.length
                 if params[:verbose] 
@@ -187,10 +190,11 @@ module Fastlane
             end
           ensure 
             # Clean up
-            Action.sh(adb_controller.command_logcat_to_file)
             for i in 0...avd_schemes.length
               # Kill all emulators
-              unless devices.match(["emulator-", avd_schemes[i].launch_avd_port].join("")).nil?
+              device = ["emulator-", avd_schemes[i].launch_avd_port].join("")
+              unless devices.match(device).nil?
+                Action.sh(adb_controller.command_logcat_to_file(device: device))
                 Action.sh(avd_controllers[i].command_kill_device)
               end
 

--- a/lib/fastlane/plugin/automated_test_emulator_run/actions/automated_test_emulator_run_action.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run/actions/automated_test_emulator_run_action.rb
@@ -149,6 +149,7 @@ module Fastlane
             
             if all_avd_launched
               UI.message("AVDs Booted!".green)
+              Action.sh(adb_controller.command_clear_logcat)
             else
               for i in 0...avd_schemes.length
                 if params[:verbose] 
@@ -186,6 +187,7 @@ module Fastlane
             end
           ensure 
             # Clean up
+            Action.sh(adb_controller.command_logcat_to_file)
             for i in 0...avd_schemes.length
               # Kill all emulators
               unless devices.match(["emulator-", avd_schemes[i].launch_avd_port].join("")).nil?

--- a/lib/fastlane/plugin/automated_test_emulator_run/actions/automated_test_emulator_run_action.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run/actions/automated_test_emulator_run_action.rb
@@ -149,10 +149,12 @@ module Fastlane
             
             if all_avd_launched
               UI.message("AVDs Booted!".green)
-              for i in 0...avd_schemes.length
-                device = ["emulator-", avd_schemes[i].launch_avd_port].join('')
-                cmd = [adb_controller.adb_path, '-s', device, 'logcat -c'].join(' ')
-                Action.sh(cmd) unless devices.match(device).nil?
+              if params[:logcat]
+                for i in 0...avd_schemes.length
+                  device = ["emulator-", avd_schemes[i].launch_avd_port].join('')
+                  cmd = [adb_controller.adb_path, '-s', device, 'logcat -c'].join(' ')
+                  Action.sh(cmd) unless devices.match(device).nil?
+                end
               end
             else
               for i in 0...avd_schemes.length
@@ -195,9 +197,11 @@ module Fastlane
               # Kill all emulators
               device = ["emulator-", avd_schemes[i].launch_avd_port].join("")
               unless devices.match(device).nil?
-                file = [device, '.log'].join('')
-                cmd = [adb_controller.adb_path, '-s', device, 'logcat -d >', file].join(' ')
-                Action.sh(cmd)
+                if params[:logcat]
+                  file = [device, '.log'].join('')
+                  cmd = [adb_controller.adb_path, '-s', device, 'logcat -d >', file].join(' ')
+                  Action.sh(cmd)
+                end
                 Action.sh(avd_controllers[i].command_kill_device)
               end
 
@@ -462,6 +466,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :verbose,
                                        env_name: "AVD_VERBOSE",
                                        description: "Allows to turn on/off mode verbose which displays output of AVDs",
+                                       default_value: false,
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :logcat,
+                                       env_name: "ADB_LOGCAT",
+                                       description: "Allows to turn logcat on/off so you can debug crashes and such",
                                        default_value: false,
                                        is_string: false,
                                        optional: true),

--- a/lib/fastlane/plugin/automated_test_emulator_run/actions/automated_test_emulator_run_action.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run/actions/automated_test_emulator_run_action.rb
@@ -150,8 +150,9 @@ module Fastlane
             if all_avd_launched
               UI.message("AVDs Booted!".green)
               for i in 0...avd_schemes.length
-                device = ["emulator-", avd_schemes[i].launch_avd_port].join("")
-                Action.sh(adb_controller.command_clear_logcat(device: device)) unless devices.match(device).nil?
+                device = ["emulator-", avd_schemes[i].launch_avd_port].join('')
+                cmd = [adb_controller.adb_path, '-s', device, 'logcat -c'].join(' ')
+                Action.sh(cmd) unless devices.match(device).nil?
               end
             else
               for i in 0...avd_schemes.length
@@ -194,7 +195,9 @@ module Fastlane
               # Kill all emulators
               device = ["emulator-", avd_schemes[i].launch_avd_port].join("")
               unless devices.match(device).nil?
-                Action.sh(adb_controller.command_logcat_to_file(device: device))
+                file = [device, '.log'].join('')
+                cmd = [adb_controller.adb_path, '-s', device, 'logcat -d >', file].join(' ')
+                Action.sh(cmd)
                 Action.sh(avd_controllers[i].command_kill_device)
               end
 

--- a/lib/fastlane/plugin/automated_test_emulator_run/factory/adb_controller_factory.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run/factory/adb_controller_factory.rb
@@ -7,8 +7,7 @@ module Fastlane
                     :command_get_devices,
                     :command_wait_for_device,
                     :command_get_avds,
-                    :command_clear_logcat,
-                    :command_logcat_to_file
+                    :adb_path
     end
 
     class AdbControllerFactory
@@ -27,8 +26,6 @@ module Fastlane
           sh_devices_adb = "devices"
           sh_wait_for_device_adb = "wait-for-device"
           sh_list_avd_adb = "list avd"
-          sh_clear_logcat_adb = "logcat -c"
-          sh_logcat_to_file = "logcat -d >"
 
           # Assemble ADB controller
           adb_controller = ADB_Controller.new
@@ -52,22 +49,7 @@ module Fastlane
            sh_wait_for_device_adb
            ].join(" ")
 
-          adb_controller.command_clear_logcat do |options|
-            [
-              path_adb,
-              "-s #{options[:device]}",
-              sh_clear_logcat_adb
-            ].join(' ')
-          end
-
-          adb_controller.command_logcat_to_file do |options|
-            [
-              path_adb,
-              "-s #{options[:device]}",
-              sh_logcat_to_file,
-              "#{options[:device]}.log"
-            ].join(' ')
-          end
+          adb_controller.adb_path = adb_path
 
           adb_controller.command_get_avds = [
            path_avdmanager_binary, 

--- a/lib/fastlane/plugin/automated_test_emulator_run/factory/adb_controller_factory.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run/factory/adb_controller_factory.rb
@@ -21,6 +21,8 @@ module Fastlane
           sh_devices_adb = "devices"
           sh_wait_for_device_adb = "wait-for-device"
           sh_list_avd_adb = "list avd"
+          sh_clear_logcat_adb = "logcat -c"
+          sh_logcat_to_file = "logcat -d > logcat.log"
 
           # Assemble ADB controller
           adb_controller = ADB_Controller.new
@@ -43,6 +45,16 @@ module Fastlane
            path_adb,
            sh_wait_for_device_adb
            ].join(" ")
+
+          adb_controller.command_clear_logcat = [
+            path_adb,
+            sh_clear_logcat_adb
+          ].join(' ')
+
+          adb_controller.command_logcat_to_file = [
+            path_adb,
+            sh_logcat_to_file
+          ].join(' ')
 
           adb_controller.command_get_avds = [
            path_avdmanager_binary, 

--- a/lib/fastlane/plugin/automated_test_emulator_run/factory/adb_controller_factory.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run/factory/adb_controller_factory.rb
@@ -28,7 +28,7 @@ module Fastlane
           sh_wait_for_device_adb = "wait-for-device"
           sh_list_avd_adb = "list avd"
           sh_clear_logcat_adb = "logcat -c"
-          sh_logcat_to_file = "logcat -d > logcat.log"
+          sh_logcat_to_file = "logcat -d >"
 
           # Assemble ADB controller
           adb_controller = ADB_Controller.new
@@ -52,15 +52,22 @@ module Fastlane
            sh_wait_for_device_adb
            ].join(" ")
 
-          adb_controller.command_clear_logcat = [
-            path_adb,
-            sh_clear_logcat_adb
-          ].join(' ')
+          adb_controller.command_clear_logcat do |options|
+            [
+              path_adb,
+              "-s #{options[:device]}",
+              sh_clear_logcat_adb
+            ].join(' ')
+          end
 
-          adb_controller.command_logcat_to_file = [
-            path_adb,
-            sh_logcat_to_file
-          ].join(' ')
+          adb_controller.command_logcat_to_file do |options|
+            [
+              path_adb,
+              "-s #{options[:device]}",
+              sh_logcat_to_file,
+              "#{options[:device]}.log"
+            ].join(' ')
+          end
 
           adb_controller.command_get_avds = [
            path_avdmanager_binary, 

--- a/lib/fastlane/plugin/automated_test_emulator_run/factory/adb_controller_factory.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run/factory/adb_controller_factory.rb
@@ -49,7 +49,7 @@ module Fastlane
            sh_wait_for_device_adb
            ].join(" ")
 
-          adb_controller.adb_path = adb_path
+          adb_controller.adb_path = path_adb
 
           adb_controller.command_get_avds = [
            path_avdmanager_binary, 

--- a/lib/fastlane/plugin/automated_test_emulator_run/factory/adb_controller_factory.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run/factory/adb_controller_factory.rb
@@ -2,7 +2,13 @@ module Fastlane
   module Factory
 
     class ADB_Controller
-      attr_accessor :command_stop, :command_start, :command_get_devices, :command_wait_for_device, :command_get_avds
+      attr_accessor :command_stop,
+                    :command_start,
+                    :command_get_devices,
+                    :command_wait_for_device,
+                    :command_get_avds,
+                    :command_clear_logcat,
+                    :command_logcat_to_file
     end
 
     class AdbControllerFactory


### PR DESCRIPTION
We needed to get the logs from logcat in our Jenkins setup.  :rocket:

adb is very particular about who owns the process and since the plugin was our tool to get adb running, we needed to add the functionality to the plugin 👍 