### PR TITLE
Use serial parameter correctly and pass list of serials from json.

### DIFF
--- a/lib/fastlane/plugin/automated_test_emulator_run/actions/automated_test_emulator_run_action.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run/actions/automated_test_emulator_run_action.rb
@@ -187,9 +187,10 @@ module Fastlane
 
             unless gradle_task.nil?
               gradle = Helper::GradleHelper.new(gradle_path: Dir["./gradlew"].last)
+              serial = avd_schemes.map { |x| "emulator-" + x.launch_avd_port }.join(",")
 
               UI.message("Using gradle task.".green)
-              gradle.trigger(task: params[:gradle_task], flags: params[:gradle_flags], serial: nil)
+              gradle.trigger(task: params[:gradle_task], flags: params[:gradle_flags], serial: serial)
             end
           ensure 
             # Clean up


### PR DESCRIPTION
This allows us to run tests only on specified devices.