### PR TITLE
Use Android command line tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ JSON file scheme:
 ```
 
 Parameters:
-<br>For official help refer to `avdmanager` binary file: `<sdk_root>/tools/bin/avdmanager create avd`
+<br>For official help refer to `avdmanager` binary file: `<sdk_root>/cmdline-tools/latest/bin/avdmanager create avd`
 - `avd_name` - name of your AVD, avoid using spaces, this field is necessary
 - `create_avd_package` - path to system image in example "system-images;android-23;google_apis;x86_64"
 - `create_avd_device` - name of your device visible on `avdmanager list device` list

--- a/lib/fastlane/plugin/automated_test_emulator_run.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run.rb
@@ -3,7 +3,7 @@ require 'fastlane/plugin/automated_test_emulator_run/version'
 module Fastlane
   module AutomatedTestEmulatorRun
     def self.all_classes
-      Dir[File.expand_path('**/{actions,factory,provider}/*.rb', File.dirname(__FILE__))]
+      Dir[File.expand_path('**/{actions,factory,provider,helper}/*.rb', File.dirname(__FILE__))]
     end
   end
 end

--- a/lib/fastlane/plugin/automated_test_emulator_run/actions/automated_test_emulator_run_action.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run/actions/automated_test_emulator_run_action.rb
@@ -386,7 +386,7 @@ module Fastlane
                                        optional: false),
           FastlaneCore::ConfigItem.new(key: :SDK_path,
                                        env_name: "SDK_PATH",
-                                       description: "The path to your android sdk directory (root). ANDROID_HOME by default",
+                                       description: "The path to your android sdk directory (root). ANDROID_SDK_HOME by default",
                                        default_value: ENV['ANDROID_SDK_HOME'] || ENV['ANDROID_HOME'],
                                        is_string: true,
                                        optional: true),

--- a/lib/fastlane/plugin/automated_test_emulator_run/actions/automated_test_emulator_run_action.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run/actions/automated_test_emulator_run_action.rb
@@ -387,7 +387,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :SDK_path,
                                        env_name: "SDK_PATH",
                                        description: "The path to your android sdk directory (root). ANDROID_HOME by default",
-                                       default_value: ENV['ANDROID_HOME'],
+                                       default_value: ENV['ANDROID_SDK_HOME'] || ENV['ANDROID_HOME'],
                                        is_string: true,
                                        optional: true),
 

--- a/lib/fastlane/plugin/automated_test_emulator_run/actions/automated_test_emulator_run_action.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run/actions/automated_test_emulator_run_action.rb
@@ -386,8 +386,8 @@ module Fastlane
                                        optional: false),
           FastlaneCore::ConfigItem.new(key: :SDK_path,
                                        env_name: "SDK_PATH",
-                                       description: "The path to your android sdk directory (root). ANDROID_SDK_HOME by default",
-                                       default_value: ENV['ANDROID_SDK_HOME'] || ENV['ANDROID_HOME'],
+                                       description: "The path to your android sdk directory (root). ANDROID_SDK_ROOT by default",
+                                       default_value: ENV['ANDROID_SDK_ROOT'] || ENV['ANDROID_HOME'],
                                        is_string: true,
                                        optional: true),
 

--- a/lib/fastlane/plugin/automated_test_emulator_run/factory/adb_controller_factory.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run/factory/adb_controller_factory.rb
@@ -16,9 +16,9 @@ module Fastlane
           UI.message(["Preparing commands for Android ADB"].join(" ").yellow)
 
           # Get paths
-          path_sdk = "#{params[:SDK_path]}"
-          path_avdmanager_binary = path_sdk + "/tools/bin/avdmanager"
-          path_adb = path_sdk + "/platform-tools/adb"
+          sdk_helper = Helper::SdkHelper.new(params)
+          path_avdmanager_binary = sdk_helper.avd_manager
+          path_adb = sdk_helper.adb
 
           # ADB shell command parts
           sh_stop_adb = "kill-server"

--- a/lib/fastlane/plugin/automated_test_emulator_run/factory/avd_controller_factory.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run/factory/avd_controller_factory.rb
@@ -18,9 +18,9 @@ module Fastlane
           UI.message(["Preparing parameters and commands for emulator:", avd_scheme.avd_name].join(" ").yellow)
 
           # Get paths
-          path_sdk = "#{params[:SDK_path]}"
-          path_avdmanager_binary = path_sdk + "/tools/bin/avdmanager"
-          path_adb = path_sdk + "/platform-tools/adb"
+          sdk_helper = Helper::SdkHelper.new(params)
+          path_avdmanager_binary = sdk_helper.avd_manager
+          path_adb = sdk_helper.adb
           path_avd = "#{params[:AVD_path]}"
 
           # Create AVD shell command parts
@@ -51,7 +51,7 @@ module Fastlane
           sh_create_config_loc = "#{path_avd}/#{avd_scheme.avd_name}.avd/config.ini"
           
           # Launch AVD shell command parts
-          sh_launch_emulator_binary = [path_sdk, "/emulator/", avd_scheme.launch_avd_launch_binary_name].join("")
+          sh_launch_emulator_binary = [sdk_helper.emulator_dir, avd_scheme.launch_avd_launch_binary_name].join("")
           sh_launch_avd_name = ["-avd ", avd_scheme.avd_name].join("")
           sh_launch_avd_additional_options = avd_scheme.launch_avd_additional_options
           sh_launch_avd_port = ["-port", avd_scheme.launch_avd_port].join(" ") 

--- a/lib/fastlane/plugin/automated_test_emulator_run/helper/sdk_tools_helper.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run/helper/sdk_tools_helper.rb
@@ -1,0 +1,35 @@
+module Fastlane
+  module Helper
+    class SdkHelper
+      def initialize(params)
+        @sdk_root_path = params[:SDK_path]
+      end
+
+      def command_line_tools_dir
+        return "#{@sdk_root_path}/cmdline-tools/latest/bin" if File.exist?("#{@sdk_root_path}/cmdline-tools/latest/bin")
+
+        return tools_dir # Fallback on old tools path
+      end
+
+      def tools_dir
+        return "#{@sdk_root_path}/tools/bin"
+      end
+
+      def platform_tools_dir
+        return "#{@sdk_root_path}/platform-tools"
+      end
+
+      def emulator_dir
+        return "#{@sdk_root_path}/emulator/"
+      end
+
+      def adb
+        return "#{platform_tools_dir}/adb"
+      end
+
+      def avd_manager
+        return "#{command_line_tools_dir}/avdmanager"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Addresses issue #38 

By default, the plugin will now use ANDROID_SDK_ROOT (with ANDROID_HOME as a fallback) as the sdk root, and will use [cmdline-tools](https://developer.android.com/studio#cmdline-tools) if they are present and installed. If the android command-line tools are not installed, then the legacy `tools/bin` path will be used instead.